### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Server for Cursor
 
+[![smithery badge](https://smithery.ai/badge/@AntDX316/MCP-Server)](https://smithery.ai/server/@AntDX316/MCP-Server)
+
 A Model Context Protocol (MCP) server implementation for Cursor IDE integration, providing a modern web dashboard and tools through SSE (Server-Sent Events) and WebSocket connections.
 
 ## Features
@@ -25,6 +27,15 @@ A Model Context Protocol (MCP) server implementation for Cursor IDE integration,
 
 ## Installation
 
+### Installing via Smithery
+
+To install MCP Server for Cursor for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@AntDX316/MCP-Server):
+
+```bash
+npx -y @smithery/cli install @AntDX316/MCP-Server --client claude
+```
+
+### Manual Installation
 1. Clone the repository:
 ```bash
 git clone <repository-url>

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - googleClientId
+      - googleClientSecret
+    properties:
+      googleClientId:
+        type: string
+        description: Google OAuth 2.0 client ID for Google Drive integration
+      googleClientSecret:
+        type: string
+        description: Google OAuth 2.0 client secret for Google Drive integration
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'python', args: ['mcp_server.py'], env: {GOOGLE_CLIENT_ID: config.googleClientId, GOOGLE_CLIENT_SECRET: config.googleClientSecret}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@AntDX316/MCP-Server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂